### PR TITLE
Add FFT image preview and ensure matplotlib installed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ torch
 transformers
 gradio
 numpy
+matplotlib
 


### PR DESCRIPTION
## Summary
- bump app version to v1.2
- add FFT image preview component using matplotlib
- include matplotlib in requirements

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689482b073e483278292aa72c0529fb1